### PR TITLE
document id parameter

### DIFF
--- a/backend/app/controllers/api/v0/researcher/stages_swagger.rb
+++ b/backend/app/controllers/api/v0/researcher/stages_swagger.rb
@@ -77,6 +77,13 @@ class Api::V0::Researcher::StagesSwagger
         'Studies'
       ]
       parameter do
+        key :name, :id
+        key :in, :path
+        key :description, 'The stage ID'
+        key :required, true
+        key :type, :number
+      end
+      parameter do
         key :name, :stage
         key :in, :body
         key :description, 'The stage data'


### PR DESCRIPTION
Otherwise swagger complains:
```
Errors:
	-attribute paths.'/research/studies/{id}/stages'. Declared path
  parameter id needs to be defined as a path parameter in path or
  operation level
  ```