### PR TITLE
Implement Heroku review apps w/ custom openstax domain

### DIFF
--- a/Dockerfile.heroku
+++ b/Dockerfile.heroku
@@ -34,6 +34,8 @@ ENV RUBY_ENV=production
 ENV RUBY_SERVE_STATIC_FILES=true
 COPY --from=node /code/frontend/dist/ ./public/
 
+# Extra comment, just to create a PR
+
 ARG SENTRY_RUBY_DSN
 ENV RAILS_ENV=production
 CMD bundle exec rake about && bundle exec rails server -b '0.0.0.0' -p $PORT

--- a/app.json
+++ b/app.json
@@ -6,28 +6,35 @@
     "Rails",
     "OpenStax"
   ],
-  "addons": [
-    "heroku-postgresql:hobby-dev"
-  ],
   "stack": "container",
-  "env": {
-    "ACCOUNTS_ENV_NAME": {
-      "required": true
-    },
-    "COOKIE_NAME": {
-      "required": true
-    },
-    "COOKIE_PRIVATE_KEY": {
-      "required": true
-    },
-    "COOKIE_PUBLIC_KEY": {
-      "required": true
-    },
-    "SECRET_KEY_BASE": {
-      "required": true
-    },
-    "SENTRY_RAILS_DSN": {
-      "required": true
+  "environments": {
+    "review": {
+      "addons": [
+        "heroku-postgresql:hobby-dev"
+      ],
+      "env": {
+        "ACCOUNTS_ENV_NAME": {
+          "required": true
+        },
+        "COOKIE_NAME": {
+          "required": true
+        },
+        "COOKIE_PRIVATE_KEY": {
+          "required": true
+        },
+        "COOKIE_PUBLIC_KEY": {
+          "required": true
+        },
+        "HOST": {
+          "required": true
+        },
+        "SECRET_KEY_BASE": {
+          "required": true
+        },
+        "SENTRY_RAILS_DSN": {
+          "required": true
+        }
+      }
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenStax Labs Research Environment ",
-  "description": "This app manages access to studies for researchers and participants, alike",
+  "description": "This app manages access to studies for researchers and participants",
   "keywords": [
     "heroku",
     "Rails",
@@ -25,6 +25,9 @@
         "COOKIE_PUBLIC_KEY": {
           "required": true
         },
+        "HEROKU_API_TOKEN": {
+          "required": true
+        },
         "HOST": {
           "required": true
         },
@@ -34,6 +37,10 @@
         "SENTRY_RAILS_DSN": {
           "required": true
         }
+      },
+      "scripts": {
+        "postdeploy": "bundle exec rake heroku:review_app_setup",
+        "pr-predestroy": "bundle exec rake heroku:review_app_predestroy"
       }
     }
   }

--- a/app.json
+++ b/app.json
@@ -7,6 +7,10 @@
     "OpenStax"
   ],
   "stack": "container",
+  "scripts": {
+    "postdeploy": "bundle exec rake heroku:review_app_setup",
+    "pr-predestroy": "bundle exec rake heroku:review_app_predestroy"
+  },
   "environments": {
     "review": {
       "addons": [
@@ -28,6 +32,12 @@
         "HEROKU_API_TOKEN": {
           "required": true
         },
+        "AWS_ACCESS_KEY_ID": {
+          "required": true
+        },
+        "AWS_SECRET_ACCESS_KEY": {
+          "required": true
+        },
         "HOST": {
           "required": true
         },
@@ -37,10 +47,6 @@
         "SENTRY_RAILS_DSN": {
           "required": true
         }
-      },
-      "scripts": {
-        "postdeploy": "bundle exec rake heroku:review_app_setup",
-        "pr-predestroy": "bundle exec rake heroku:review_app_predestroy"
       }
     }
   }

--- a/app.json
+++ b/app.json
@@ -42,7 +42,7 @@
           "required": true
         },
         "HOST": {
-          "required": true
+          "required": false
         },
         "SECRET_KEY_BASE": {
           "required": true

--- a/app.json
+++ b/app.json
@@ -38,6 +38,9 @@
         "AWS_SECRET_ACCESS_KEY": {
           "required": true
         },
+        "AWS_REGION": {
+          "required": true
+        },
         "HOST": {
           "required": true
         },

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "OpenStax Labs Research Environment ",
+  "description": "This app manages access to studies for researchers and participants, alike",
+  "keywords": [
+    "heroku",
+    "Rails",
+    "OpenStax"
+   ],
+   "stack": "container"
+}
+

--- a/app.json
+++ b/app.json
@@ -5,7 +5,29 @@
     "heroku",
     "Rails",
     "OpenStax"
-   ],
-   "stack": "container"
+  ],
+  "addons": [
+    "heroku-postgresql:hobby-dev"
+  ],
+  "stack": "container",
+  "env": {
+    "ACCOUNTS_ENV_NAME": {
+      "required": true
+    },
+    "COOKIE_NAME": {
+      "required": true
+    },
+    "COOKIE_PRIVATE_KEY": {
+      "required": true
+    },
+    "COOKIE_PUBLIC_KEY": {
+      "required": true
+    },
+    "SECRET_KEY_BASE": {
+      "required": true
+    },
+    "SENTRY_RAILS_DSN": {
+      "required": true
+    }
+  }
 }
-

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -18,6 +18,9 @@ gem 'bootsnap', '>= 1.4.4', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+# Use Heroku for review apps
+gem 'platform-api'
+
 # Versioned API tools
 gem 'versionist'
 

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -33,6 +33,9 @@ gem 'openstax_healthcheck'
 # For installing secrets on deploy
 gem 'aws-sdk-ssm'
 
+# For deploying domain names
+gem 'aws-sdk-route53'
+
 gem 'dotenv-rails'
 
 gem 'will_paginate', '~> 3.1.7'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -89,6 +89,9 @@ GEM
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
+    aws-sdk-route53 (1.54.0)
+      aws-sdk-core (~> 3, >= 3.119.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-ssm (1.116.0)
       aws-sdk-core (~> 3, >= 3.119.0)
       aws-sigv4 (~> 1.1)
@@ -318,6 +321,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-route53
   aws-sdk-ssm
   bootsnap (>= 1.4.4)
   byebug

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    erubis (2.7.0)
+    excon (0.85.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -139,6 +141,12 @@ GEM
     ffi (1.15.3)
     globalid (0.5.2)
       activesupport (>= 5.0)
+    heroics (0.1.2)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
+      webrick
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
@@ -164,7 +172,9 @@ GEM
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
+    moneta (1.0.0)
     msgpack (1.4.2)
+    multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
     nokogiri (1.12.4)
@@ -178,6 +188,10 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    platform-api (3.3.0)
+      heroics (~> 0.1.1)
+      moneta (~> 1.0.0)
+      rate_throttle_client (~> 0.1.0)
     puma (5.4.0)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -214,6 +228,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    rate_throttle_client (0.1.2)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -291,6 +306,7 @@ GEM
       activesupport (>= 3)
       railties (>= 3)
       yard (~> 0.9.20)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -315,6 +331,7 @@ DEPENDENCIES
   openstax_healthcheck
   openstax_swagger!
   pg (>= 0.18, < 2.0)
+  platform-api
   puma (~> 5.0)
   rack-cors
   rails (~> 6.1.3)

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -113,7 +113,7 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  host = ENV.fetch('HOST', "pr-#{ENV['HEROKU_PR_NUMBER']}.labs.sandbox.openstax.org" )
+  host = ENV.fetch('HOST', "pr-#{ENV['HEROKU_PR_NUMBER']}.labs.sandbox.openstax.org")
 
   routes.default_url_options.merge!(
     {

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -113,13 +113,15 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
+  host = ENV.fetch('HOST', "pr-#{ENV['HEROKU_PR_NUMBER']}.labs.sandbox.openstax.org" )
+
   routes.default_url_options.merge!(
     {
-      host: ENV.fetch('HOST'),
+      host: host,
       protocol: 'https'
     }
   )
 
-  config.hosts << ENV.fetch('HOST')
+  config.hosts << host
 
 end

--- a/backend/config/secrets.yml
+++ b/backend/config/secrets.yml
@@ -34,7 +34,11 @@ test:
       encryption_private_key: 'RvGHVZ/kvzUAA5Z3t68+FNhuMCJxkzv+'
 
 production:
-  host: <%= ENV['HOST'] %>
+  host: <% if ENV['HOST'] %>
+        <%= ENV['HOST'] %>
+        <% else %>
+        <%= "pr-#{ENV['HEROKU_PR_NUMBER']}.labs.sandbox.openstax.org" %>
+        <% end %>
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   sentry:
     dsn: <%= ENV['SENTRY_RAILS_DSN'] %>

--- a/backend/lib/tasks/review_app_predestroy.rake
+++ b/backend/lib/tasks/review_app_predestroy.rake
@@ -5,7 +5,7 @@ namespace :heroku do
   task :review_app_predestroy do
     require 'aws-sdk-route53'
 
-    openstax_domain = 'labs.sandbox.openstax.org.'
+    openstax_domain = 'labs.sandbox.openstax.org'
 
     # Environment variables are provided when specified in app.json
     heroku_app_name = ENV['HEROKU_APP_NAME']
@@ -20,7 +20,8 @@ namespace :heroku do
     # Delete CNAME record from Route53 - credentials are in ENV
     aws_creds = aws::AssumeRoleCredentials.new( {role_arn: 'arn:aws:iam::373045849756:role/research-labs-dns ', role_session_name: 'HerokuLabsReview' } )
     r53 = Aws::Route53::Client.new({credentials: aws_creds})
-    domain = r53.list_hosted_zones.hosted_zones.select { |zone| zone[:name] == openstax_domain }[0]
+    # DNS zone name ends with a fullstop
+    domain = r53.list_hosted_zones.hosted_zones.select { |zone| zone[:name] == "#{openstax_domain}." }[0]
     abort "Domain #{openstax_domain} does not exist" unless domain
     zone_id = domain.id
 

--- a/backend/lib/tasks/review_app_predestroy.rake
+++ b/backend/lib/tasks/review_app_predestroy.rake
@@ -26,9 +26,9 @@ namespace :heroku do
       })
     r53 = Aws::Route53::Client.new({ credentials: aws_creds })
     # DNS zone name ends with a fullstop
-    domain = r53.list_hosted_zones.hosted_zones.select { |zone|
-      zone[:name] == "#{openstax_domain}."
-    }[0]
+    domain = r53.list_hosted_zones.hosted_zones.select do |zone|
+               zone[:name] == "#{openstax_domain}."
+             end [0]
     abort "Domain #{openstax_domain} does not exist" unless domain
     zone_id = domain.id
 

--- a/backend/lib/tasks/review_app_predestroy.rake
+++ b/backend/lib/tasks/review_app_predestroy.rake
@@ -1,25 +1,51 @@
+# frozen_string_literal: true
+
 namespace :heroku do
   desc 'Delete the custom domain record set up for the Review App'
   task :review_app_predestroy do
-#    require 'dnsimple'
-#
-#    # Cleanup subdomain DNS record for Heroku review app
-#    clutter_domain = 'clutter.com'.freeze
-#    heroku_app_name    = ENV['HEROKU_APP_NAME']
-#    dnsimple_account_id = ENV['DNSIMPLE_ACCOUNT_ID']
-#
-#    # Extract out "pr-<pull request ID>" from default name
-#    pr_number = heroku_app_name.match(/.*(pr-\d+)/).captures.first
-#    subdomain = "account-#{pr_number}"
-#
-#    dnsimple_client = Dnsimple::Client.new access_token: ENV['DNSIMPLE_ACCESS_TOKEN']
-#
-#    # Remove record from DNSimple
-#    resp = dnsimple_client.zones.zone_records dnsimple_account_id, clutter_domain, { filter: { name_like: subdomain } }
-#    if resp.total_entries == 1
-#      record_id = resp.data[0].id
-#      dnsimple_client.zones.delete_zone_record dnsimple_account_id, clutter_domain, record_id
-#    end
+    require 'aws-sdk-route53'
+
+    openstax_domain = 'labs.sandbox.openstax.org.'
+
+    # Environment variables are provided when specified in app.json
+    heroku_app_name = ENV['HEROKU_APP_NAME']
+    pr_number = ENV['HEROKU_PR_NUMBER']
+    subdomain = "PR-#{pr_number}"
+    hostname = [subdomain, openstax_domain].join('.')
+
+    # Fetch CNAME value
+    heroku_client = PlatformAPI.connect_oauth ENV['HEROKU_API_TOKEN']
+    heroku_domain = heroku_client.domain.info(heroku_app_name, hostname)['cname']
+
+    # Delete CNAME record from Route53 - credentials are in ENV
+    aws_creds = aws::AssumeRoleCredentials.new( {role_arn: 'arn:aws:iam::373045849756:role/research-labs-dns ', role_session_name: 'HerokuLabsReview' } )
+    r53 = Aws::Route53::Client.new({credentials: aws_creds})
+    domain = r53.list_hosted_zones.hosted_zones.select { |zone| zone[:name] == openstax_domain }[0]
+    abort "Domain #{openstax_domain} does not exist" unless domain
+    zone_id = domain.id
+
+    r53.change_resource_record_sets(
+      {
+        hosted_zone_id: zone_id,
+        change_batch: {
+          changes: [
+            {
+              action: 'DELETE',
+              resource_record_set: {
+                name: hostname,
+                type: 'CNAME',
+                ttl: 60,
+                resource_records: [
+                  {
+                    value: heroku_domain
+                  }
+                ]
+              }
+            }
+          ],
+          comment: "Review domain for labs #{subdomain}"
+        }
+      })
+
   end
 end
-

--- a/backend/lib/tasks/review_app_predestroy.rake
+++ b/backend/lib/tasks/review_app_predestroy.rake
@@ -1,0 +1,25 @@
+namespace :heroku do
+  desc 'Delete the custom domain record set up for the Review App'
+  task :review_app_predestroy do
+#    require 'dnsimple'
+#
+#    # Cleanup subdomain DNS record for Heroku review app
+#    clutter_domain = 'clutter.com'.freeze
+#    heroku_app_name    = ENV['HEROKU_APP_NAME']
+#    dnsimple_account_id = ENV['DNSIMPLE_ACCOUNT_ID']
+#
+#    # Extract out "pr-<pull request ID>" from default name
+#    pr_number = heroku_app_name.match(/.*(pr-\d+)/).captures.first
+#    subdomain = "account-#{pr_number}"
+#
+#    dnsimple_client = Dnsimple::Client.new access_token: ENV['DNSIMPLE_ACCESS_TOKEN']
+#
+#    # Remove record from DNSimple
+#    resp = dnsimple_client.zones.zone_records dnsimple_account_id, clutter_domain, { filter: { name_like: subdomain } }
+#    if resp.total_entries == 1
+#      record_id = resp.data[0].id
+#      dnsimple_client.zones.delete_zone_record dnsimple_account_id, clutter_domain, record_id
+#    end
+  end
+end
+

--- a/backend/lib/tasks/review_app_setup.rake
+++ b/backend/lib/tasks/review_app_setup.rake
@@ -28,9 +28,9 @@ namespace :heroku do
       })
     r53 = Aws::Route53::Client.new({ credentials: aws_creds })
     # DNS zone name ends with a fullstop
-    domain = r53.list_hosted_zones.hosted_zones.select { |zone|
-      zone[:name] == "#{openstax_domain}."
-    }[0]
+    domain = r53.list_hosted_zones.hosted_zones.select do |zone|
+               zone[:name] == "#{openstax_domain}."
+             end [0]
     abort "Domain #{openstax_domain} does not exist" unless domain
     zone_id = domain.id
 

--- a/backend/lib/tasks/review_app_setup.rake
+++ b/backend/lib/tasks/review_app_setup.rake
@@ -7,7 +7,7 @@ namespace :heroku do
     require 'aws-sdk-route53'
 
     # Q: do we ever want to do non-sandbox PR review?
-    openstax_domain = 'labs.sandbox.openstax.org.'
+    openstax_domain = 'labs.sandbox.openstax.org'
 
     # Environment variables are provided when specified in app.json
     heroku_app_name = ENV['HEROKU_APP_NAME']
@@ -24,7 +24,8 @@ namespace :heroku do
     # Create or update (UPSERT) CNAME record in Route53 - credentials are in ENV
     aws_creds = aws::AssumeRoleCredentials.new( {role_arn: 'arn:aws:iam::373045849756:role/research-labs-dns', role_session_name: 'HerokuLabsReview' } )
     r53 = Aws::Route53::Client.new({credentials: aws_creds})
-    domain = r53.list_hosted_zones.hosted_zones.select { |zone| zone[:name] == openstax_domain }[0]
+    # DNS zone name ends with a fullstop
+    domain = r53.list_hosted_zones.hosted_zones.select { |zone| zone[:name] == "#{openstax_domain}." }[0]
     abort "Domain #{openstax_domain} does not exist" unless domain
     zone_id = domain.id
 

--- a/backend/lib/tasks/review_app_setup.rake
+++ b/backend/lib/tasks/review_app_setup.rake
@@ -13,19 +13,24 @@ namespace :heroku do
     heroku_app_name = ENV['HEROKU_APP_NAME']
     pr_number = ENV['HEROKU_PR_NUMBER']
     subdomain = "PR-#{pr_number}"
-
-    heroku_client = PlatformAPI.connect_oauth ENV['HEROKU_API_TOKEN']
+    hostname = [subdomain, openstax_domain].join('.')
 
     # Configure Custom Domain in Heroku
-    hostname = [subdomain, openstax_domain].join('.')
+    heroku_client = PlatformAPI.connect_oauth ENV['HEROKU_API_TOKEN']
     heroku_client.domain.create(heroku_app_name, hostname: hostname)
     heroku_domain = heroku_client.domain.info(heroku_app_name, hostname)['cname']
 
     # Create or update (UPSERT) CNAME record in Route53 - credentials are in ENV
-    aws_creds = aws::AssumeRoleCredentials.new( {role_arn: 'arn:aws:iam::373045849756:role/research-labs-dns', role_session_name: 'HerokuLabsReview' } )
-    r53 = Aws::Route53::Client.new({credentials: aws_creds})
+    aws_creds = Aws::AssumeRoleCredentials.new(
+      {
+        role_arn: 'arn:aws:iam::373045849756:role/research-labs-dns',
+        role_session_name: 'HerokuLabsReview'
+      })
+    r53 = Aws::Route53::Client.new({ credentials: aws_creds })
     # DNS zone name ends with a fullstop
-    domain = r53.list_hosted_zones.hosted_zones.select { |zone| zone[:name] == "#{openstax_domain}." }[0]
+    domain = r53.list_hosted_zones.hosted_zones.select { |zone|
+      zone[:name] == "#{openstax_domain}."
+    }[0]
     abort "Domain #{openstax_domain} does not exist" unless domain
     zone_id = domain.id
 

--- a/backend/lib/tasks/review_app_setup.rake
+++ b/backend/lib/tasks/review_app_setup.rake
@@ -1,0 +1,40 @@
+namespace :heroku do
+  desc 'review app postdeploy script'
+  task :review_app_setup do
+    require 'platform-api'
+
+    openstax_domain = 'sandbox.openstax.org'.freeze
+
+    # Environment variables are provided when specified in app.json
+    heroku_app_name = ENV['HEROKU_APP_NAME']
+    # dnsimple_account_id = ENV['DNSIMPLE_ACCOUNT_ID']
+
+    # Extract out "pr-<pull request ID>" from default name
+    pr_number = ENV['HEROKU_PR_NUMBER']
+    # subdomain = "labs-#{pr_number}"
+    subdomain = "review"
+    type = { type: 'CNAME' }
+
+    heroku_client = PlatformAPI.connect_oauth ENV['HEROKU_API_TOKEN']
+
+    # Configure Custom Domain in Heroku
+    hostname = [subdomain, openstax_domain].join('.')
+    heroku_client.domain.create(heroku_app_name, hostname: hostname)
+    heroku_domain = heroku_client.domain.info(heroku_app_name, hostname)["cname"]
+
+#    # Create CNAME record in Route53
+#    opts = type.merge({ name: subdomain, content: heroku_domain })
+#    # Query DNSimple to see if we already have a record.
+#    resp = dnsimple_client.zones.zone_records dnsimple_account_id, clutter_domain, { filter: { name_like: subdomain } }
+#
+#    # If no record found, create a new one
+#    if resp.total_entries == 0
+#      dnsimple_client.zones.create_zone_record dnsimple_account_id, clutter_domain, opts
+#    # On changes or redeploy of the review app, update the record to the new heroku domain
+#    elsif resp.total_entries == 1
+#      record_id = resp.data[0].id
+#      client.zones.update_zone_record dnsimple_account_id, clutter_domain, record_id, opts
+#    end
+  end
+end
+

--- a/backend/lib/tasks/review_app_setup.rake
+++ b/backend/lib/tasks/review_app_setup.rake
@@ -22,7 +22,7 @@ namespace :heroku do
     heroku_domain = heroku_client.domain.info(heroku_app_name, hostname)['cname']
 
     # Create or update (UPSERT) CNAME record in Route53 - credentials are in ENV
-    aws_creds = aws::AssumeRoleCredentials.new( {role_arn: 'arn:aws:iam::373045849756:role/research-labs-dns ', role_session_name: 'HerokuLabsReview' } )
+    aws_creds = aws::AssumeRoleCredentials.new( {role_arn: 'arn:aws:iam::373045849756:role/research-labs-dns', role_session_name: 'HerokuLabsReview' } )
     r53 = Aws::Route53::Client.new({credentials: aws_creds})
     domain = r53.list_hosted_zones.hosted_zones.select { |zone| zone[:name] == openstax_domain }[0]
     abort "Domain #{openstax_domain} does not exist" unless domain

--- a/backend/lib/tasks/review_app_setup.rake
+++ b/backend/lib/tasks/review_app_setup.rake
@@ -61,7 +61,7 @@ namespace :heroku do
 
     # Wait for change to be active
     delay = 1
-    while change.change_info.status == 'PENDING' & delay < 30
+    while (change.change_info.status == 'PENDING') & (delay < 30)
       change = r53.get_change({ id: change_id })
       sleep delay
       delay *= 2


### PR DESCRIPTION
Using a new robot user (heroku-labs) that can only assume one role (research-labs-dns) that can only do a limited sot of operations on the labs[.sandbox].openstax.org hosted zones. This allows automated creation of deployments for every PR, under an openstax.org domain, so all the cookie work!